### PR TITLE
Spawn obj

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,9 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 crossbeam = "0.6.0"
+futures-preview = "0.3.0-alpha.13"
 num_cpus = "1.9.0"
 lazy_static = "1.2.0"
 
 [dev-dependencies]
 romio = "0.3.0-alpha.2"
-
-[dev-dependencies.futures]
-version = "0.3.0-alpha.13"
-package = "futures-preview"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,12 +92,14 @@ pub struct ThreadPool {
 
 impl ThreadPool {
     /// Create a new threadpool instance.
+    #[inline]
     pub fn new() -> Self {
         Self::with_setup(|| ())
     }
 
     /// Create a new instance with a method that's called for every thread
     /// that's spawned.
+    #[inline]
     pub fn with_setup<F>(f: F) -> Self
     where
         F: Fn() + Send + Sync + 'static,
@@ -122,6 +124,7 @@ impl ThreadPool {
     }
 
     /// Spawn a new future on the threadpool.
+    #[inline]
     pub fn spawn<F>(&self, future: F)
     where
         F: Future<Output = ()> + Send + 'static,
@@ -133,6 +136,7 @@ impl ThreadPool {
     }
 
     /// Spawn a boxed future on the threadpool.
+    #[inline]
     pub fn spawn_obj(&self, future: FutureObj<'static, ()>) {
         self.queue
             .tx
@@ -158,6 +162,7 @@ impl ThreadPool {
 ///     }
 /// }
 /// ```
+#[inline]
 pub fn spawn<F>(future: F)
 where
     F: Future<Output = ()> + Send + 'static,
@@ -187,6 +192,7 @@ struct AtomicFuture {
 }
 
 impl fmt::Debug for AtomicFuture {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         "AtomicFuture".fmt(f)
     }
@@ -201,6 +207,7 @@ const REPOLL: usize = 2; // --> POLLING
 const COMPLETE: usize = 3; // No transitions out
 
 impl Task {
+    #[inline]
     fn new<F: Future<Output = ()> + Send + 'static>(future: F, queue: Arc<TaskQueue>) -> Task {
         let future: Arc<AtomicFuture> = Arc::new(AtomicFuture {
             queue,
@@ -211,6 +218,7 @@ impl Task {
         unsafe { task(future) }
     }
 
+    #[inline]
     fn new_boxed(future: FutureObj<'static, ()>, queue: Arc<TaskQueue>) -> Task {
         let future: Arc<AtomicFuture> = Arc::new(AtomicFuture {
             queue,
@@ -221,6 +229,7 @@ impl Task {
         unsafe { task(future) }
     }
 
+    #[inline]
     unsafe fn poll(self) {
         self.0.status.store(POLLING, SeqCst);
         let waker = ManuallyDrop::new(waker(&*self.0));
@@ -240,6 +249,7 @@ impl Task {
     }
 }
 
+#[inline]
 unsafe fn waker(task: *const AtomicFuture) -> Waker {
     Waker::new_unchecked(RawWaker::new(
         task as *const (),
@@ -251,6 +261,7 @@ unsafe fn waker(task: *const AtomicFuture) -> Waker {
     ))
 }
 
+#[inline]
 unsafe fn clone_raw(this: *const ()) -> RawWaker {
     let task = clone_task(this as *const AtomicFuture);
     RawWaker::new(
@@ -263,10 +274,12 @@ unsafe fn clone_raw(this: *const ()) -> RawWaker {
     )
 }
 
+#[inline]
 unsafe fn drop_raw(this: *const ()) {
     drop(task(this as *const AtomicFuture))
 }
 
+#[inline]
 unsafe fn wake_raw(this: *const ()) {
     let task = ManuallyDrop::new(task(this as *const AtomicFuture));
     let mut status = task.0.status.load(SeqCst);
@@ -300,10 +313,12 @@ unsafe fn wake_raw(this: *const ()) {
     }
 }
 
+#[inline]
 unsafe fn task(future: *const AtomicFuture) -> Task {
     Task(Arc::from_raw(future))
 }
 
+#[inline]
 unsafe fn clone_task(future: *const AtomicFuture) -> Task {
     let task = task(future);
     forget(task.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ use std::task::{Poll, RawWaker, RawWakerVTable, Waker};
 use std::thread;
 
 use crossbeam::channel;
+use futures::future::FutureObj;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
Adds a `spawn_obj` method to the threadpool which allows us to prevent double boxing of futures in some scenarios by being able to pass a boxed future down directly. Thanks!