### PR TITLE
Update futures-preview to 0.3.0-alpha.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 crossbeam = "0.6.0"
-futures-preview = "0.3.0-alpha.15"
+futures-preview = "0.3.0-alpha.16"
 num_cpus = "1.9.0"
 lazy_static = "1.2.0"
 
 [dev-dependencies]
-romio = "0.3.0-alpha.6"
+romio = "0.3.0-alpha.7"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ configuration. It exposes the most minimal API possible.
 
 ## Example
 ```rust
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use std::io;
 
@@ -29,14 +29,14 @@ fn main() -> io::Result<()> {
 
         println!("Listening on 127.0.0.1:7878");
 
-        while let Some(stream) = await!(incoming.next()) {
+        while let Some(stream) = incoming.next().await {
             let stream = stream?;
             let addr = stream.peer_addr()?;
 
             juliex::spawn(async move {
                 println!("Accepting stream from: {}", addr);
 
-                await!(echo_on(stream)).unwrap();
+                echo_on(stream).await.unwrap();
 
                 println!("Closing stream from: {}", addr);
             });
@@ -48,7 +48,7 @@ fn main() -> io::Result<()> {
 
 async fn echo_on(stream: TcpStream) -> io::Result<()> {
     let (mut reader, mut writer) = stream.split();
-    await!(reader.copy_into(&mut writer))?;
+    reader.copy_into(&mut writer).await?;
     Ok(())
 }
 ```

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use std::io;
 
@@ -15,14 +15,14 @@ fn main() -> io::Result<()> {
 
         println!("Listening on 127.0.0.1:7878");
 
-        while let Some(stream) = await!(incoming.next()) {
+        while let Some(stream) = incoming.next().await {
             let stream = stream?;
             let addr = stream.peer_addr()?;
 
             juliex::spawn(async move {
                 println!("Accepting stream from: {}", addr);
 
-                await!(echo_on(stream)).unwrap();
+                echo_on(stream).await.unwrap();
 
                 println!("Closing stream from: {}", addr);
             });
@@ -34,6 +34,6 @@ fn main() -> io::Result<()> {
 
 async fn echo_on(stream: TcpStream) -> io::Result<()> {
     let (mut reader, mut writer) = stream.split();
-    await!(reader.copy_into(&mut writer))?;
+    reader.copy_into(&mut writer).await?;
     Ok(())
 }

--- a/examples/http.rs
+++ b/examples/http.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use std::io;
 
@@ -16,12 +16,12 @@ fn main() -> io::Result<()> {
 
         println!("Listening on 127.0.0.1:7878");
 
-        while let Some(stream) = await!(incoming.next()) {
+        while let Some(stream) = incoming.next().await {
             let stream = stream?;
 
             juliex::spawn(async move {
               let (_, mut writer) = stream.split();
-              await!(writer.write_all(b"HTTP/1.1 200 OK\r\nContent-Length:0\r\n\r\n")).unwrap();
+              writer.write_all(b"HTTP/1.1 200 OK\r\nContent-Length:0\r\n\r\n").await.unwrap();
             });
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ## Example
 //! ```rust,no_run
-//! #![feature(async_await, await_macro)]
+//! #![feature(async_await)]
 //!
 //! use std::io;
 //!
@@ -29,14 +29,14 @@
 //!
 //!         println!("Listening on 127.0.0.1:7878");
 //!
-//!         while let Some(stream) = await!(incoming.next()) {
+//!         while let Some(stream) = incoming.next().await {
 //!             let stream = stream?;
 //!             let addr = stream.peer_addr()?;
 //!
 //!             juliex::spawn(async move {
 //!                 println!("Accepting stream from: {}", addr);
 //!
-//!                 await!(echo_on(stream)).unwrap();
+//!                 echo_on(stream).await.unwrap();
 //!
 //!                 println!("Closing stream from: {}", addr);
 //!             });
@@ -48,7 +48,7 @@
 //!
 //! async fn echo_on(stream: TcpStream) -> io::Result<()> {
 //!     let (mut reader, mut writer) = stream.split();
-//!     await!(reader.copy_into(&mut writer))?;
+//!     reader.copy_into(&mut writer).await?;
 //!     Ok(())
 //! }
 //! ```
@@ -149,7 +149,7 @@ impl ThreadPool {
 ///
 /// ## Example
 /// ```rust,ignore
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// use std::thread;
 /// use futures::executor;
 ///


### PR DESCRIPTION
`await` syntax was implemented in https://github.com/rust-lang/rust/pull/60586, and nightly-2019-05-09 has been released with the changes. Also, `await!` macro will be removed in the future.

Then, futures 0.3.0-alpha.16 was released.

Refs: [migration tool](https://github.com/taiki-e/replace-await)