### PR TITLE
Scoped Pool for scheduling non 'static futures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,20 +55,12 @@
 
 #![cfg_attr(test, feature(async_await))]
 
-use std::cell::{RefCell, UnsafeCell};
-use std::fmt;
+use std::cell::RefCell;
 use std::future::Future;
-use std::mem::{forget, ManuallyDrop};
-use std::sync::{
-    atomic::{AtomicUsize, Ordering::SeqCst},
-    Arc, Weak,
-};
-use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::sync::{Arc, Weak};
 use std::thread;
-
 use crossbeam::channel;
 use futures::future::BoxFuture;
-use futures::prelude::*;
 
 #[cfg(test)]
 mod tests;
@@ -106,11 +98,11 @@ impl ThreadPool {
     {
         let f = Arc::new(f);
         let (tx, rx) = channel::unbounded();
-        let queue = Arc::new(TaskQueue { tx, rx });
+        let queue = Arc::new(tx);
         let max_cpus = num_cpus::get() * 2;
         for _ in 0..max_cpus {
             let f = f.clone();
-            let rx = queue.rx.clone();
+            let rx = rx.clone();
             let queue = Arc::downgrade(&queue);
             thread::spawn(move || {
                 QUEUE.with(|q| *q.borrow_mut() = queue.clone());
@@ -130,7 +122,6 @@ impl ThreadPool {
         F: Future<Output = ()> + Send + 'static,
     {
         self.queue
-            .tx
             .send(Task::new(future, self.queue.clone()))
             .unwrap();
     }
@@ -139,7 +130,6 @@ impl ThreadPool {
     #[inline]
     pub fn spawn_boxed(&self, future: BoxFuture<'static, ()>) {
         self.queue
-            .tx
             .send(Task::new_boxed(future, self.queue.clone()))
             .unwrap();
     }
@@ -169,192 +159,14 @@ where
 {
     QUEUE.with(|q| {
         if let Some(q) = q.borrow().upgrade() {
-            q.tx.send(Task::new(future, q.clone())).unwrap();
+            q.send(Task::new(future, q.clone())).unwrap();
         } else {
             THREAD_POOL.spawn(future);
         }
     });
 }
 
-struct TaskQueue {
-    tx: channel::Sender<Task>,
-    rx: channel::Receiver<Task>,
-}
+pub mod task;
+use task::{Task, TaskQueue};
 
-impl Default for TaskQueue {
-    fn default() -> TaskQueue {
-        let (tx, rx) = channel::unbounded();
-        TaskQueue { tx, rx }
-    }
-}
-
-#[derive(Clone, Debug)]
-#[repr(transparent)]
-struct Task(Arc<AtomicFuture>);
-
-struct AtomicFuture {
-    queue: Arc<TaskQueue>,
-    status: AtomicUsize,
-    future: UnsafeCell<BoxFuture<'static, ()>>,
-}
-
-impl fmt::Debug for AtomicFuture {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        "AtomicFuture".fmt(f)
-    }
-}
-
-unsafe impl Send for AtomicFuture {}
-unsafe impl Sync for AtomicFuture {}
-
-const WAITING: usize = 0; // --> POLLING
-const POLLING: usize = 1; // --> WAITING, REPOLL, or COMPLETE
-const REPOLL: usize = 2; // --> POLLING
-const COMPLETE: usize = 3; // No transitions out
-
-impl Task {
-    #[inline]
-    fn new<F: Future<Output = ()> + Send + 'static>(future: F, queue: Arc<TaskQueue>) -> Task {
-        let future: Arc<AtomicFuture> = Arc::new(AtomicFuture {
-            queue,
-            status: AtomicUsize::new(WAITING),
-            future: UnsafeCell::new(future.boxed()),
-        });
-        let future: *const AtomicFuture = Arc::into_raw(future) as *const AtomicFuture;
-        unsafe { task(future) }
-    }
-
-    #[inline]
-    fn new_boxed(future: BoxFuture<'static, ()>, queue: Arc<TaskQueue>) -> Task {
-        let future: Arc<AtomicFuture> = Arc::new(AtomicFuture {
-            queue,
-            status: AtomicUsize::new(WAITING),
-            future: UnsafeCell::new(future),
-        });
-        let future: *const AtomicFuture = Arc::into_raw(future) as *const AtomicFuture;
-        unsafe { task(future) }
-    }
-
-    #[inline]
-    unsafe fn poll(self) {
-        self.0.status.store(POLLING, SeqCst);
-        let waker = ManuallyDrop::new(waker(&*self.0));
-        let mut cx = Context::from_waker(&waker);
-        loop {
-            if let Poll::Ready(_) = (&mut *self.0.future.get()).poll_unpin(&mut cx) {
-                break self.0.status.store(COMPLETE, SeqCst);
-            }
-            match self
-                .0
-                .status
-                .compare_exchange(POLLING, WAITING, SeqCst, SeqCst)
-            {
-                Ok(_) => break,
-                Err(_) => self.0.status.store(POLLING, SeqCst),
-            }
-        }
-    }
-}
-
-#[inline]
-unsafe fn waker(task: *const AtomicFuture) -> Waker {
-    Waker::from_raw(RawWaker::new(
-        task as *const (),
-        &RawWakerVTable::new(clone_raw, wake_raw, wake_ref_raw, drop_raw),
-    ))
-}
-
-#[inline]
-unsafe fn clone_raw(this: *const ()) -> RawWaker {
-    let task = clone_task(this as *const AtomicFuture);
-    RawWaker::new(
-        Arc::into_raw(task.0) as *const (),
-        &RawWakerVTable::new(clone_raw, wake_raw, wake_ref_raw, drop_raw),
-    )
-}
-
-#[inline]
-unsafe fn drop_raw(this: *const ()) {
-    drop(task(this as *const AtomicFuture))
-}
-
-#[inline]
-unsafe fn wake_raw(this: *const ()) {
-    let task = task(this as *const AtomicFuture);
-    let mut status = task.0.status.load(SeqCst);
-    loop {
-        match status {
-            WAITING => {
-                match task
-                    .0
-                    .status
-                    .compare_exchange(WAITING, POLLING, SeqCst, SeqCst)
-                {
-                    Ok(_) => {
-                        task.0.queue.tx.send(clone_task(&*task.0)).unwrap();
-                        break;
-                    }
-                    Err(cur) => status = cur,
-                }
-            }
-            POLLING => {
-                match task
-                    .0
-                    .status
-                    .compare_exchange(POLLING, REPOLL, SeqCst, SeqCst)
-                {
-                    Ok(_) => break,
-                    Err(cur) => status = cur,
-                }
-            }
-            _ => break,
-        }
-    }
-}
-
-#[inline]
-unsafe fn wake_ref_raw(this: *const ()) {
-    let task = ManuallyDrop::new(task(this as *const AtomicFuture));
-    let mut status = task.0.status.load(SeqCst);
-    loop {
-        match status {
-            WAITING => {
-                match task
-                    .0
-                    .status
-                    .compare_exchange(WAITING, POLLING, SeqCst, SeqCst)
-                {
-                    Ok(_) => {
-                        task.0.queue.tx.send(clone_task(&*task.0)).unwrap();
-                        break;
-                    }
-                    Err(cur) => status = cur,
-                }
-            }
-            POLLING => {
-                match task
-                    .0
-                    .status
-                    .compare_exchange(POLLING, REPOLL, SeqCst, SeqCst)
-                {
-                    Ok(_) => break,
-                    Err(cur) => status = cur,
-                }
-            }
-            _ => break,
-        }
-    }
-}
-
-#[inline]
-unsafe fn task(future: *const AtomicFuture) -> Task {
-    Task(Arc::from_raw(future))
-}
-
-#[inline]
-unsafe fn clone_task(future: *const AtomicFuture) -> Task {
-    let task = task(future);
-    forget(task.clone());
-    task
-}
+pub mod scoped;

--- a/src/scoped.rs
+++ b/src/scoped.rs
@@ -1,0 +1,110 @@
+//! Pretty much exactly the default executor, except
+//! integrates with `crossbeam::scope` and executes non
+//! `'static` futures.
+//!
+//! ## Example
+//! ```rust,no_run
+//! #![feature(async_await)]
+//! fn main() {
+//!     let not_copy = String::from("hello world!");
+//!     crossbeam::scope(|scope| {
+//!
+//!         // Compare with this (does not compile)
+//!         // use futures::executor::ThreadPool;
+//!         // use futures::task::SpawnExt;
+//!         // let tp = ThreadPool::new().expect("error creating thread pool");
+//!
+//!         let tp = juliex::scoped::Pool::new(&scope);
+//!         let fut = async || {
+//!             println!("{} from future!", not_copy);
+//!         };
+//!         tp.spawn(fut());
+//!
+//!     }).expect("threads panicked");
+//! }
+//! ```
+use super::task::{Task, TaskQueue};
+use std::{sync::Arc, marker::PhantomData, mem::drop};
+pub struct Pool<'a> {
+    queue: Arc<TaskQueue>,
+    waiter: WaitGroup,
+    _marker: PhantomData<fn(&'a ())>
+}
+
+use crossbeam::{channel, thread::Scope, sync::WaitGroup};
+use futures::future::BoxFuture;
+use futures::prelude::{Future, FutureExt};
+impl<'a> Pool<'a> {
+    /// Spawn a future on the threadpool.
+    #[inline] pub fn spawn<F: Future<Output=()> + Send + 'a>(&self, f: F) {
+        self.spawn_boxed(f.boxed())
+    }
+
+    /// Spawn a boxed future on the threadpool.
+    /// # Safety
+    #[inline] pub fn spawn_boxed(&self, future: BoxFuture<'a, ()>) {
+        let task;
+
+        // See #safety above
+        unsafe {
+            task = Task::new_boxed(std::mem::transmute(future), self.queue.clone());
+        }
+        self.queue
+            .send(task)
+            .unwrap();
+    }
+
+    /// Create a new threadpool with default settings
+    pub fn new(scope: &Scope<'a>) -> Self {
+        Self::with_setup(scope, 2*num_cpus::get(), ||{})
+    }
+
+    /// Create a new threadpool with specified workers, and
+    /// initialization function.
+    pub fn with_setup<F>(scope: &Scope<'a>, num_workers: usize, f: F) -> Self
+    where F: Fn() + Send + Sync + 'a {
+        let f = Arc::new(f);
+        let (tx, rx) = channel::unbounded();
+        let waiter = WaitGroup::new();
+
+        for _ in 0..num_workers {
+            let rx = rx.clone();
+            let f = f.clone();
+            let waiter = waiter.clone();
+            scope.spawn(move |_| { f(); worker_loop(rx); drop(waiter); });
+        }
+
+        Pool { queue: Arc::new(tx), waiter,
+               _marker: PhantomData }
+    }
+
+    /// Return the wait group (``)
+    pub fn finish(self) -> WaitGroup {
+        self.waiter
+    }
+}
+
+
+use crossbeam::channel::Receiver;
+#[inline] fn worker_loop(rx: Receiver<Task>) {
+    for task in rx {
+        unsafe { task.poll() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn scoped_pool() {
+        let not_copy = String::from("hello world!");
+        let not_copy = &not_copy; // ensure no move
+        crossbeam::scope(|scope| {
+            let tp = super::Pool::new(&scope);
+            let fut = async || {
+                assert_eq!(not_copy, "hello world!");
+            };
+            tp.spawn(fut());
+
+        }).expect("threads panicked");
+    }
+}

--- a/src/scoped.rs
+++ b/src/scoped.rs
@@ -25,6 +25,7 @@
 //! ```
 use super::task::{Task, TaskQueue};
 use std::{sync::Arc, marker::PhantomData, mem::drop};
+#[derive(Clone)]
 pub struct Pool<'a> {
     queue: Arc<TaskQueue>,
     waiter: WaitGroup,
@@ -32,8 +33,7 @@ pub struct Pool<'a> {
 }
 
 use crossbeam::{channel, thread::Scope, sync::WaitGroup};
-use futures::future::BoxFuture;
-use futures::prelude::{Future, FutureExt};
+use futures::future::*;
 impl<'a> Pool<'a> {
     /// Spawn a future on the threadpool.
     #[inline] pub fn spawn<F: Future<Output=()> + Send + 'a>(&self, f: F) {

--- a/src/scoped.rs
+++ b/src/scoped.rs
@@ -15,7 +15,7 @@
 //!         // let tp = ThreadPool::new().expect("error creating thread pool");
 //!
 //!         let tp = juliex::scoped::Pool::new(&scope);
-//!         let fut = async || {
+//!         let fut = || async {
 //!             println!("{} from future!", not_copy);
 //!         };
 //!         tp.spawn(fut());
@@ -100,7 +100,7 @@ mod tests {
         let not_copy = &not_copy; // ensure no move
         crossbeam::scope(|scope| {
             let tp = super::Pool::new(&scope);
-            let fut = async || {
+            let fut = || async move {
                 assert_eq!(not_copy, "hello world!");
             };
             tp.spawn(fut());

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,0 +1,185 @@
+use std::cell::UnsafeCell;
+use std::fmt;
+use std::future::Future;
+use std::mem::{forget, ManuallyDrop};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering::SeqCst},
+    Arc,
+};
+use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use crossbeam::channel;
+use futures::future::BoxFuture;
+use futures::prelude::*;
+
+pub type TaskQueue = channel::Sender<Task>;
+
+#[derive(Clone, Debug)]
+#[repr(transparent)]
+pub struct Task(Arc<AtomicFuture>);
+
+struct AtomicFuture {
+    queue: Arc<TaskQueue>,
+    status: AtomicUsize,
+    future: UnsafeCell<BoxFuture<'static, ()>>,
+}
+
+impl fmt::Debug for AtomicFuture {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        "AtomicFuture".fmt(f)
+    }
+}
+
+unsafe impl Send for AtomicFuture {}
+unsafe impl Sync for AtomicFuture {}
+
+const WAITING: usize = 0; // --> POLLING
+const POLLING: usize = 1; // --> WAITING, REPOLL, or COMPLETE
+const REPOLL: usize = 2; // --> POLLING
+const COMPLETE: usize = 3; // No transitions out
+
+impl Task {
+    #[inline]
+    pub fn new<F: Future<Output = ()> + Send + 'static>(future: F, queue: Arc<TaskQueue>) -> Task {
+        let future: Arc<AtomicFuture> = Arc::new(AtomicFuture {
+            queue,
+            status: AtomicUsize::new(WAITING),
+            future: UnsafeCell::new(future.boxed()),
+        });
+        let future: *const AtomicFuture = Arc::into_raw(future) as *const AtomicFuture;
+        unsafe { task(future) }
+    }
+
+    #[inline]
+    pub fn new_boxed(future: BoxFuture<'static, ()>, queue: Arc<TaskQueue>) -> Task {
+        let future: Arc<AtomicFuture> = Arc::new(AtomicFuture {
+            queue,
+            status: AtomicUsize::new(WAITING),
+            future: UnsafeCell::new(future),
+        });
+        let future: *const AtomicFuture = Arc::into_raw(future) as *const AtomicFuture;
+        unsafe { task(future) }
+    }
+
+    #[inline]
+    pub unsafe fn poll(self) {
+        self.0.status.store(POLLING, SeqCst);
+        let waker = ManuallyDrop::new(waker(&*self.0));
+        let mut cx = Context::from_waker(&waker);
+        loop {
+            if let Poll::Ready(_) = (&mut *self.0.future.get()).poll_unpin(&mut cx) {
+                break self.0.status.store(COMPLETE, SeqCst);
+            }
+            match self
+                .0
+                .status
+                .compare_exchange(POLLING, WAITING, SeqCst, SeqCst)
+            {
+                Ok(_) => break,
+                Err(_) => self.0.status.store(POLLING, SeqCst),
+            }
+        }
+    }
+}
+
+#[inline]
+unsafe fn waker(task: *const AtomicFuture) -> Waker {
+    Waker::from_raw(RawWaker::new(
+        task as *const (),
+        &RawWakerVTable::new(clone_raw, wake_raw, wake_ref_raw, drop_raw),
+    ))
+}
+
+#[inline]
+unsafe fn clone_raw(this: *const ()) -> RawWaker {
+    let task = clone_task(this as *const AtomicFuture);
+    RawWaker::new(
+        Arc::into_raw(task.0) as *const (),
+        &RawWakerVTable::new(clone_raw, wake_raw, wake_ref_raw, drop_raw),
+    )
+}
+
+#[inline]
+unsafe fn drop_raw(this: *const ()) {
+    drop(task(this as *const AtomicFuture))
+}
+
+#[inline]
+unsafe fn wake_raw(this: *const ()) {
+    let task = task(this as *const AtomicFuture);
+    let mut status = task.0.status.load(SeqCst);
+    loop {
+        match status {
+            WAITING => {
+                match task
+                    .0
+                    .status
+                    .compare_exchange(WAITING, POLLING, SeqCst, SeqCst)
+                {
+                    Ok(_) => {
+                        task.0.queue.send(clone_task(&*task.0)).unwrap();
+                        break;
+                    }
+                    Err(cur) => status = cur,
+                }
+            }
+            POLLING => {
+                match task
+                    .0
+                    .status
+                    .compare_exchange(POLLING, REPOLL, SeqCst, SeqCst)
+                {
+                    Ok(_) => break,
+                    Err(cur) => status = cur,
+                }
+            }
+            _ => break,
+        }
+    }
+}
+
+#[inline]
+unsafe fn wake_ref_raw(this: *const ()) {
+    let task = ManuallyDrop::new(task(this as *const AtomicFuture));
+    let mut status = task.0.status.load(SeqCst);
+    loop {
+        match status {
+            WAITING => {
+                match task
+                    .0
+                    .status
+                    .compare_exchange(WAITING, POLLING, SeqCst, SeqCst)
+                {
+                    Ok(_) => {
+                        task.0.queue.send(clone_task(&*task.0)).unwrap();
+                        break;
+                    }
+                    Err(cur) => status = cur,
+                }
+            }
+            POLLING => {
+                match task
+                    .0
+                    .status
+                    .compare_exchange(POLLING, REPOLL, SeqCst, SeqCst)
+                {
+                    Ok(_) => break,
+                    Err(cur) => status = cur,
+                }
+            }
+            _ => break,
+        }
+    }
+}
+
+#[inline]
+unsafe fn task(future: *const AtomicFuture) -> Task {
+    Task(Arc::from_raw(future))
+}
+
+#[inline]
+unsafe fn clone_task(future: *const AtomicFuture) -> Task {
+    let task = task(future);
+    forget(task.clone());
+    task
+}


### PR DESCRIPTION
closes #19 

Provide `juliex::scope::Pool` that integrates with `crossbeam::scope` to allow easy spawning of not  `'static` futures.  We also took the liberty of the following simple refactoring:

1.  Move `struct Task` into separate module for usage across different executors.
1.  Replace `TaskQueue` as synonym for `channel::Sender` as only the sender is actually used in the queueing parts of the system.   The receiver is only used by the worker threads.
1.  Fix existing tests for change in `TaskQueue`, and add new tests for scoped pool.
