### PR TITLE
Maintenance notice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "juliex"
 edition = "2018"
-version = "0.3.0-alpha.7"
+version = "0.3.0-alpha.8"
 authors = ["Without Boats <boats@mozilla.com>"]
 description = "a very basic future executor"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "juliex"
 edition = "2018"
-version = "0.3.0-alpha.6"
+version = "0.3.0-alpha.7"
 authors = ["Without Boats <boats@mozilla.com>"]
 description = "a very basic future executor"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # juliex - a minimal futures executor
 
+__Note: This library is not actively being developed. If you're looking for an
+`async/await` compatible runtime consider using
+[`async-std`](https://github.com/async-rs/async-std).__
+
 juliex is a concurrent executor for Rust futures. It is implemented as a
 threadpool executor using a single, shared queue. Algorithmically, it is very
 similar to the Threadpool executor provided by the futures crate. The main


### PR DESCRIPTION
Adds a notice to the top of the repo that `romio` is not actively being developed, and points them to `async-std` instead. We've had some people ask about the relationship and status between projects in the past, and this should hopefully help. Thanks!

ps. I also forgot to push the labels for the past few releases, so they're part of this PR now. Think that's okay, haha.